### PR TITLE
(85) User sign in/out events are sent to the API to be recorded in the audit log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'omniauth'
 gem 'omniauth-auth0', '~> 2.0.0'
 
+# API requests
+gem 'faraday'
+
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
@@ -60,4 +63,5 @@ group :test do
   gem 'capybara', require: false
   gem 'database_cleaner'
   gem 'poltergeist'
+  gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'omniauth'
 gem 'omniauth-auth0', '~> 2.0.0'
 
 # API requests
-gem 'faraday'
+gem 'httparty'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
@@ -289,10 +291,10 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   dotenv-rails
-  faraday
   govuk_elements_rails
   govuk_frontend_toolkit
   haml-rails
+  httparty
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mini_racer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
@@ -99,6 +101,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hashdiff (0.3.7)
     hashie (3.5.7)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
@@ -227,6 +230,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
+    safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -265,6 +269,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -281,6 +289,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   dotenv-rails
+  faraday
   govuk_elements_rails
   govuk_frontend_toolkit
   haml-rails
@@ -301,6 +310,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,17 +3,13 @@ class SessionsController < ApplicationController
     user = User.from_omniauth(auth_hash)
     session[:user_id] = user.id
 
-    conn.post '/v1/events/user_signed_in' do |req|
-      req.params['user_id'] = user.id
-    end
+    Auditor.new.user_signed_in(user_id: user.id)
 
     redirect_to '/tasks', notice: 'You are now signed in'
   end
 
   def destroy
-    conn.post '/v1/events/user_signed_out' do |req|
-      req.params['user_id'] = session[:user_id]
-    end
+    Auditor.new.user_signed_out(user_id: session[:user_id])
 
     session[:user_id] = nil
 
@@ -24,9 +20,5 @@ class SessionsController < ApplicationController
 
   def auth_hash
     request.env['omniauth.auth']
-  end
-
-  def conn
-    Faraday.new(url: ENV['API_ROOT'])
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,10 +3,18 @@ class SessionsController < ApplicationController
     user = User.from_omniauth(auth_hash)
     session[:user_id] = user.id
 
+    conn.post '/v1/events/user_signed_in' do |req|
+      req.params['user_id'] = user.id
+    end
+
     redirect_to '/tasks', notice: 'You are now signed in'
   end
 
   def destroy
+    conn.post '/v1/events/user_signed_out' do |req|
+      req.params['user_id'] = session[:user_id]
+    end
+
     session[:user_id] = nil
 
     redirect_to '/', notice: 'You are now signed out'
@@ -16,5 +24,9 @@ class SessionsController < ApplicationController
 
   def auth_hash
     request.env['omniauth.auth']
+  end
+
+  def conn
+    Faraday.new(url: ENV['API_ROOT'])
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,8 @@ module DataSubmissionService
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.autoload_paths << Rails.root.join('lib')
+    config.eager_load_paths << Rails.root.join('lib')
   end
 end

--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -2,3 +2,4 @@ DATABASE_URL=postgres://postgres@db:5432/DataSubmissionService_development?templ
 AUTH0_DOMAIN=
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=
+API_ROOT=

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,7 @@ services:
     environment:
       RAILS_ENV: "test"
       DATABASE_URL: "postgres://postgres@db-test:5432/DataSubmissionService_test?template=template0&pool=5&encoding=unicode"
+      API_ROOT: "https://ccs.api/"
     env_file:
       - docker-compose.env
     volumes:

--- a/lib/auditor.rb
+++ b/lib/auditor.rb
@@ -1,0 +1,12 @@
+class Auditor
+  include HTTParty
+  base_uri ENV['API_ROOT'] + 'v1/events'
+
+  def user_signed_in(user_id:)
+    self.class.post('/user_signed_in', query: { user_id: user_id })
+  end
+
+  def user_signed_out(user_id:)
+    self.class.post('/user_signed_out', query: { user_id: user_id })
+  end
+end

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -4,20 +4,42 @@ RSpec.feature 'Signing in as a user' do
   scenario 'Signing in successfully' do
     mock_sso_with(email: 'email@example.com')
 
+    stub_request(:post, 'https://ccs.api/v1/events/user_signed_in')
+      .with(query: hash_including(user_id: /.+/))
+      .to_return(status: 201)
+
     visit '/tasks'
 
     click_on 'Sign in'
 
     expect(page).to have_flash_message 'You are now signed in'
+
+    expect(
+      a_request(:post, 'https://ccs.api/v1/events/user_signed_in')
+      .with(query: hash_including(user_id: /.+/))
+    ).to have_been_made.once
   end
 
   scenario 'Signing out' do
     mock_sso_with(email: 'email@example.com')
+
+    stub_request(:post, 'https://ccs.api/v1/events/user_signed_in')
+      .with(query: hash_including(user_id: /.+/))
+      .to_return(status: 201)
+
+    stub_request(:post, 'https://ccs.api/v1/events/user_signed_out')
+      .with(query: hash_including(user_id: /.+/))
+      .to_return(status: 201)
 
     visit '/tasks'
     click_on 'Sign in'
     click_on 'Sign out'
 
     expect(page).to have_flash_message 'You are now signed out'
+
+    expect(
+      a_request(:post, 'https://ccs.api/v1/events/user_signed_out')
+      .with(query: hash_including(user_id: /.+/))
+    ).to have_been_made.once
   end
 end

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -4,42 +4,20 @@ RSpec.feature 'Signing in as a user' do
   scenario 'Signing in successfully' do
     mock_sso_with(email: 'email@example.com')
 
-    stub_request(:post, 'https://ccs.api/v1/events/user_signed_in')
-      .with(query: hash_including(user_id: /.+/))
-      .to_return(status: 201)
-
     visit '/tasks'
 
     click_on 'Sign in'
 
     expect(page).to have_flash_message 'You are now signed in'
-
-    expect(
-      a_request(:post, 'https://ccs.api/v1/events/user_signed_in')
-      .with(query: hash_including(user_id: /.+/))
-    ).to have_been_made.once
   end
 
   scenario 'Signing out' do
     mock_sso_with(email: 'email@example.com')
-
-    stub_request(:post, 'https://ccs.api/v1/events/user_signed_in')
-      .with(query: hash_including(user_id: /.+/))
-      .to_return(status: 201)
-
-    stub_request(:post, 'https://ccs.api/v1/events/user_signed_out')
-      .with(query: hash_including(user_id: /.+/))
-      .to_return(status: 201)
 
     visit '/tasks'
     click_on 'Sign in'
     click_on 'Sign out'
 
     expect(page).to have_flash_message 'You are now signed out'
-
-    expect(
-      a_request(:post, 'https://ccs.api/v1/events/user_signed_out')
-      .with(query: hash_including(user_id: /.+/))
-    ).to have_been_made.once
   end
 end

--- a/spec/lib/auditor_spec.rb
+++ b/spec/lib/auditor_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Auditor do
+  describe '.user_signed_in' do
+    it 'posts a sign in event to the API' do
+      stub_request(:post, 'https://ccs.api/v1/events/user_signed_in')
+        .with(query: hash_including(user_id: /.+/))
+        .to_return(status: 201)
+
+      Auditor.new.user_signed_in(user_id: '1234')
+
+      expect(
+        a_request(:post, 'https://ccs.api/v1/events/user_signed_in')
+        .with(query: { user_id: '1234' })
+      ).to have_been_made.once
+    end
+  end
+
+  describe '.user_signed_out' do
+    it 'posts a sign out event to the API' do
+      stub_request(:post, 'https://ccs.api/v1/events/user_signed_out')
+        .with(query: hash_including(user_id: /.+/))
+        .to_return(status: 201)
+
+      Auditor.new.user_signed_out(user_id: '5678')
+
+      expect(
+        a_request(:post, 'https://ccs.api/v1/events/user_signed_out')
+        .with(query: { user_id: '5678' })
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,4 +56,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:each, type: :feature) do
+    # Stub audit requests
+    stub_request(:any, %r{/v1/events/}).and_return(status: 201)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,11 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+# Stub external HTTP requests
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Whenever a user successfully signs in or out send an HTTP request to the `/v1/events/` audit endpoints so they are recorded in the audit log.