### PR TITLE
422 Adding In Service Alert component

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -30,21 +30,17 @@ $govuk-colours: (
   "turquoise": #28a197,
   "light-blue": #2b8cc4,
   "blue": #005ea5,
-
   "primary": #9B1A47,
   "secondary": #016065,
-
   "black": #0b0c0c,
   "grey-1": #6f777b,
   "grey-2": #bfc1c3,
   "grey-3": #dee0e2,
   "grey-4": #f8f8f8,
   "white": #ffffff,
-
   "link": #005EA5,
   "link-hover": #2B8CC4,
   "link-visited": #4C2C92,
-
   "failure": #B10E1E,
   "warning": #DE8F1A,
   "success": #0EB163

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -16,3 +16,4 @@
 @import "panel/panel";
 @import "task/task";
 @import "task_signpost/task_signpost";
+@import "in_service_alerts/in_service_alerts";

--- a/app/assets/stylesheets/components/in_service_alerts/_in_service_alerts.scss
+++ b/app/assets/stylesheets/components/in_service_alerts/_in_service_alerts.scss
@@ -1,0 +1,24 @@
+@import "govuk-frontend/components/inset-text/inset-text";
+
+//==============//MIXINS
+//background-color lighten and border color for alert messages
+@mixin bgalert-color-borderleft-color($bordercolour, $percentage) {
+    background-color: lighten($bordercolour, $percentage);
+    border-left-color: $bordercolour;
+};
+
+.ccs-in_service_alert {
+    @extend .govuk-inset-text;
+  @at-root #{&}--notice {
+    @include bgalert-color-borderleft-color(govuk-colour("grey-1"), 50%);
+  }
+  @at-root #{&}--failure {
+    @include bgalert-color-borderleft-color(govuk-colour("failure"), 55%);
+  }
+  @at-root #{&}--success {
+    @include bgalert-color-borderleft-color(govuk-colour("success"), 55%);
+  }
+  @at-root #{&}--warning {
+    @include bgalert-color-borderleft-color(govuk-colour("warning"), 40%);
+  }
+}

--- a/app/views/shared/_alert.html.haml
+++ b/app/views/shared/_alert.html.haml
@@ -1,5 +1,5 @@
 .grid-row
   .column-full
-    .error-summary
-      %h2.heading-medium.error-summary-heading
+    .ccs-in_service_alert.ccs-in_service_alert--failure{:role => "alert", :tabindex =>"-1"}
+      %h2.govuk-heading-s
         = flash[:alert]


### PR DESCRIPTION
The system uses alerts on occasion, these have now been styled for error (failure), warning, success and notice alerts

As there is no GOVUK component for this, we created our own component and styled it