### PR TITLE
release-65/Bump rails & actionview to 5.2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [release-65] - 2020-11-11
+
+- Work required for ticket RMI-242
+- Bump rails from 5.2.4.3 to 5.2.4.4
+- [Security] Bump actionview from 5.2.4.3 to 5.2.4.4
+
 ## [release-64] - 2020-11-09
 
 - Added SimpleCov and Code Climate to Travis build
@@ -338,6 +344,7 @@
 
 Initial release
 
+[release-65]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-64...release-65
 [release-64]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-63...release-64
 [release-63]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-62...release-63
 [release-62]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-61...release-62

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.4.3'
+gem 'rails', '~> 5.2.4.4'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server


### PR DESCRIPTION
## [release-65] - 2020-11-11

- Work required for JIRA ticket RMI-242
- Bump rails from 5.2.4.3 to 5.2.4.4
- [Security] Bump actionview from 5.2.4.3 to 5.2.4.4
