### PR TITLE
Feature/rmi 301 deploy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ before_deploy:
   - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
   - echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
   - sudo apt-get update -qq
-  - sudo apt-get install cf-cli
-  - cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-  - cf install-plugin blue-green-deploy -f -r CF-Community
+  - sudo apt-get install cf7-cli
 deploy:
   - provider: script
     script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s staging

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -131,8 +131,4 @@ sed "s/CF_SPACE/$CF_SPACE/g" manifest-template.yml | sed "s/MEMORY_LIMIT/$MEMORY
 # push
 cd .. || exit
 
-# create an app idempotently with the v3 cli
-cf v3-create-app ccs-rmi-app-"$CF_SPACE"
-cf v3-apply-manifest -f CF/"$CF_SPACE".manifest.yml
-# do a zero down time deployment with the v3 cli
-cf v3-zdt-push ccs-rmi-app-"$CF_SPACE"
+cf push ccs-rmi-app-"$CF_SPACE" -f CF/"$CF_SPACE".manifest.yml  --strategy rolling


### PR DESCRIPTION
## Description
Switched from cf CLI v6 to cf CLI v7 and from v3-zdt deploy to rolling strategy
https://crowncommercialservice.atlassian.net/browse/RMI-301

## Why was the change made?
Deployment builds had begun failing as previously used command was unsupported.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

 [X] This change requires a documentation update

## How was the change tested?
Manual testing.