### PR TITLE
RMI-27-Remove-Beta-Banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [release-70] - 2021-03-18
+
+- RMI-27: Removed Beta Banner.
+
 ## [release-69] - 2021-03-03
 
 - RMI-313: gem update to resolve dependabot alert and resolving obsolete rubocop config.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,16 +24,6 @@
     = render 'shared/header', no_navigation: false
 
     .govuk-width-container
-      .govuk-phase-banner
-        %p.govuk-phase-banner__content
-          %strong.govuk-tag.govuk-phase-banner__content__tag
-            beta
-          %span.govuk-phase-banner__text
-            This is a new service – your
-            %a.govuk-link{:href => survey_url} feedback
-            will help us to improve it.
-
-    .govuk-width-container
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 
         = render 'shared/alert' if flash[:alert]

--- a/app/views/layouts/errors.html.haml
+++ b/app/views/layouts/errors.html.haml
@@ -24,16 +24,6 @@
     = render 'shared/header', no_navigation: false
 
     .govuk-width-container
-      .govuk-phase-banner
-        %p.govuk-phase-banner__content
-          %strong.govuk-tag.govuk-phase-banner__content__tag
-            beta
-          %span.govuk-phase-banner__text
-            This is a new service – your
-            %a.govuk-link{:href => survey_url} feedback
-            will help us to improve it.
-
-    .govuk-width-container
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 
         = render 'shared/alert' if flash[:alert]


### PR DESCRIPTION
## Description
RMI-27

## Why was the change made?
No longer in Beta.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Locally and visually.
