### PR TITLE
RMI-333-Session-Management

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,6 +17,14 @@ class SessionsController < ApplicationController
     redirect_to '/'
   end
 
+  def terminate
+    Auditor.new.user_terminated(user_id: params[:auth_id])
+
+    session[:auth_id] = nil
+
+    redirect_to '/'
+  end
+
   protected
 
   def auth_hash

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/auth/failure', to: 'errors#auth_failure'
   get '/sign_out', to: 'sessions#destroy', as: :sign_out
+  post '/terminate_user/:auth_id', to: 'sessions#terminate'
   get '/style_guide', to: 'styleguide#index'
   get '/support', to: 'support#index'
   get '/support/frameworks', to: 'support#frameworks'

--- a/lib/auditor.rb
+++ b/lib/auditor.rb
@@ -9,4 +9,8 @@ class Auditor
   def user_signed_out(user_id:)
     self.class.post('/user_signed_out', query: { user_id: user_id })
   end
+
+  def user_terminated(user_id:)
+    self.class.post('/user_terminated', query: { user_id: user_id })
+  end
 end


### PR DESCRIPTION
## Description
RMI-333

## Why was the change made?
Conclave session management work - Required for SSO integration.

## Are there any dependencies required for this change?
API:
'session_store.rb'
'events_controllers.rb'
'user_terminated.rb'

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature