### PR TITLE
Conclave deployment fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
     on:
       branch: develop
   - provider: script
-    script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s preprod
+    script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s conclave-development
     on:
       branch: conclave
   - provider: script

--- a/CF/create-cf-space.sh
+++ b/CF/create-cf-space.sh
@@ -74,7 +74,7 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
 if [[ "$CF_SPACE" == "conclave-development" ]]
 then
-  "$CF_SPACE" = "preprod"
+  CF_SPACE = "preprod"
 fi
 
 # install cf-blue-green-deploy plugin

--- a/CF/create-cf-space.sh
+++ b/CF/create-cf-space.sh
@@ -50,13 +50,13 @@ fi
 POSTGRES_SIZE="tiny-unencrypted-10"
 REDIS_SIZE="tiny-3.2"
 
-if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "preprod" || "$CF_SPACE" == "prod" ]]; then
+if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "conclave-development" || "$CF_SPACE" == "prod" ]]; then
   echo " *********************************************"
   echo "    The '$CF_SPACE' space will be selected"
   echo "     This deploys the apps as HA with"
   echo "      production like resource sizes"
   echo " For feature testing, choose a space with a"
-  echo "      name other than staging / preprod / prod"
+  echo "      name other than staging / conclave-development / prod"
   echo " *********************************************"
 
   POSTGRES_SIZE="small-ha-10"
@@ -69,6 +69,13 @@ cf login -u "$CF_USER" -p "$CF_PASS" -o "$CF_ORG" -a "$CF_API_ENDPOINT" -s devel
 # create and target space (user must be org admin)
 cf create-space "$CF_SPACE"
 cf target -o "$CF_ORG" -s "$CF_SPACE"
+
+# This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
+# It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
+if [[ "$CF_SPACE" == "conclave-development" ]]
+then
+  "$CF_SPACE" = "preprod"
+fi
 
 # install cf-blue-green-deploy plugin
 cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org

--- a/CF/create-cf-space.sh
+++ b/CF/create-cf-space.sh
@@ -72,7 +72,8 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 
 # This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
-if [[ "$CF_SPACE" == "conclave-development" ]] then;
+if [[ "$CF_SPACE" == "conclave-development" ]]
+then
   CF_SPACE="preprod"
 fi
 

--- a/CF/create-cf-space.sh
+++ b/CF/create-cf-space.sh
@@ -72,9 +72,8 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 
 # This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
-if [[ "$CF_SPACE" == "conclave-development" ]]
-then
-  CF_SPACE = "preprod"
+if [[ "$CF_SPACE" == "conclave-development" ]] then;
+  CF_SPACE="preprod"
 fi
 
 # install cf-blue-green-deploy plugin

--- a/CF/create-user-services.sh
+++ b/CF/create-user-services.sh
@@ -53,9 +53,8 @@ cf login -u "$CF_USER" -p "$CF_PASS" -o "$CF_ORG" -s "$CF_SPACE" -a "$CF_API_END
 
 # This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
-if [[ "$CF_SPACE" == "conclave-development" ]]
-then
-  CF_SPACE = "preprod"
+if [[ "$CF_SPACE" == "conclave-development" ]] then;
+  CF_SPACE="preprod"
 fi
 
 # source environment variables

--- a/CF/create-user-services.sh
+++ b/CF/create-user-services.sh
@@ -55,7 +55,7 @@ cf login -u "$CF_USER" -p "$CF_PASS" -o "$CF_ORG" -s "$CF_SPACE" -a "$CF_API_END
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
 if [[ "$CF_SPACE" == "conclave-development" ]]
 then
-  "$CF_SPACE" = "preprod"
+  CF_SPACE = "preprod"
 fi
 
 # source environment variables

--- a/CF/create-user-services.sh
+++ b/CF/create-user-services.sh
@@ -51,6 +51,13 @@ fi
 # login
 cf login -u "$CF_USER" -p "$CF_PASS" -o "$CF_ORG" -s "$CF_SPACE" -a "$CF_API_ENDPOINT"
 
+# This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
+# It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
+if [[ "$CF_SPACE" == "conclave-development" ]]
+then
+  "$CF_SPACE" = "preprod"
+fi
+
 # source environment variables
 source .env.cf."$CF_SPACE"
 

--- a/CF/create-user-services.sh
+++ b/CF/create-user-services.sh
@@ -53,7 +53,8 @@ cf login -u "$CF_USER" -p "$CF_PASS" -o "$CF_ORG" -s "$CF_SPACE" -a "$CF_API_END
 
 # This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
-if [[ "$CF_SPACE" == "conclave-development" ]] then;
+if [[ "$CF_SPACE" == "conclave-development" ]]
+then
   CF_SPACE="preprod"
 fi
 

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -83,7 +83,7 @@ then
     fi
   fi
   
-  if [[ "$CF_SPACE" == "preprod" ]]
+  if [[ "$CF_SPACE" == "conclave-development" ]]
   then
     if [[ ! "$BRANCH" == "conclave" ]]
     then
@@ -104,13 +104,13 @@ then
   fi
 fi
 
-if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "preprod" || "$CF_SPACE" == "prod" ]]; then
+if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "conclave-development" || "$CF_SPACE" == "prod" ]]; then
   echo " *********************************************"
   echo "    The '$CF_SPACE' space will be selected"
   echo "     This deploys the apps as HA with"
   echo "      production like resource sizes"
   echo " For feature testing, choose a space with a"
-  echo "      name other than staging / preprod / prod"
+  echo "      name other than staging / conclave-development / prod"
   echo " *********************************************"
 
   MEMORY_LIMIT="512M"
@@ -124,6 +124,13 @@ cd "$SCRIPT_PATH" || exit
 # login and target space
 cf login -u "$CF_USER" -p "$CF_PASS" -o "$CF_ORG" -a "$CF_API_ENDPOINT" -s "$CF_SPACE"
 cf target -o "$CF_ORG" -s "$CF_SPACE"
+
+# This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
+# It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
+if [[ "$CF_SPACE" == "conclave-development" ]]
+then
+  "$CF_SPACE" = "preprod"
+fi
 
 # generate manifest
 sed "s/CF_SPACE/$CF_SPACE/g" manifest-template.yml | sed "s/MEMORY_LIMIT/$MEMORY_LIMIT/g" | sed "s/INSTANCE_COUNT/$INSTANCE_COUNT/g" > "$CF_SPACE.manifest.yml"

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -127,9 +127,8 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 
 # This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
-if [[ "$CF_SPACE" == "conclave-development" ]]
-then
-  CF_SPACE = "preprod"
+if [[ "$CF_SPACE" == "conclave-development" ]] then;
+  CF_SPACE="preprod"
 fi
 
 # generate manifest

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -129,7 +129,7 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
 if [[ "$CF_SPACE" == "conclave-development" ]]
 then
-  "$CF_SPACE" = "preprod"
+  CF_SPACE = "preprod"
 fi
 
 # generate manifest

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -123,7 +123,8 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 
 # This is a fix for the environment being renamed - all apps and services are still ending with "-preprod".
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
-if [[ "$CF_SPACE" == "conclave-development" ]] then;
+if [[ "$CF_SPACE" == "conclave-development" ]]
+then
   CF_SPACE="preprod"
 fi
 

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -117,10 +117,6 @@ if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "conclave-development" || "$CF_
   INSTANCE_COUNT="3"
 fi
 
-
-
-cd "$SCRIPT_PATH" || exit
-
 # login and target space
 cf login -u "$CF_USER" -p "$CF_PASS" -o "$CF_ORG" -a "$CF_API_ENDPOINT" -s "$CF_SPACE"
 cf target -o "$CF_ORG" -s "$CF_SPACE"
@@ -130,6 +126,8 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 if [[ "$CF_SPACE" == "conclave-development" ]] then;
   CF_SPACE="preprod"
 fi
+
+cd "$SCRIPT_PATH" || exit
 
 # generate manifest
 sed "s/CF_SPACE/$CF_SPACE/g" manifest-template.yml | sed "s/MEMORY_LIMIT/$MEMORY_LIMIT/g" | sed "s/INSTANCE_COUNT/$INSTANCE_COUNT/g" > "$CF_SPACE.manifest.yml"


### PR DESCRIPTION
This is a fix for the 'preprod' environment in CF being renamed to 'conclave-development'.
All apps and services are still ending with "-preprod" in conclave-development env, so this is a fix for the pipeline, to continue deploying as normal. Compatible with all of our envs/branches now.