### PR TITLE
CON-335-Remove-Old-Testing-Links

### DIFF
--- a/app/views/errors/auth_failure.html.haml
+++ b/app/views/errors/auth_failure.html.haml
@@ -11,9 +11,6 @@
     %p{class: 'govuk-!-margin-top-9'}
       = button_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"
 
-    %p{class: 'govuk-!-margin-top-9'}
-      = button_to 'ConclaveSSO Sign in', '/auth/conclavesso', class: 'govuk-button govuk-button--start', id: 'sign-in2', 'aria-label' => "[Testing ConclaveSSO] Sign in to the service"
-
     %p
       If you are unable to sign in or do not receive a password reset email from the service contact
       = support_email_address

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -23,9 +23,6 @@
     %p{class: 'govuk-!-margin-top-9'}
       = button_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"
 
-    %p{class: 'govuk-!-margin-top-9'}
-      = button_to 'ConclaveSSO Sign in', '/auth/conclavesso', class: 'govuk-button govuk-button--start', id: 'sign-in2', 'aria-label' => "[Testing ConclaveSSO] Sign in to the service"
-
     %h2.govuk-heading-m
       If you’re having trouble signing in
 


### PR DESCRIPTION
## Description
RMI-335

## Why was the change made?
Tidy up and remove old testing links, for the sso, now it is implemented.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix
