### PR TITLE
RMI-478-Update-HTST-Config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,7 +104,7 @@ Rails.application.configure do
 
   config.action_dispatch.default_headers.merge!(
     # Value given by https://www.gov.uk/service-manual/technology/using-https
-    'Strict-Transport-Security' => 'max-age=31536000, includeSubDomains; preload;',
+    'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains; preload',
 
     'Expect-CT' => 'enforce, max-age=10'
   )


### PR DESCRIPTION
## Description
RMI-478

## Why was the change made?
Invalid HTST config.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Documentation confirmed.
