### PR TITLE
RMI-401-Replace-Framework-Terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [release-83] - 2022-09-28
+## [release-83] - 2022-09-29
 
 - RMI-401: Replaced UI instaces of "Framework" with "Agreement", to web pages, or where it will be seen on the site.
 - RMI-353: Add additional year filter to the completed tasks page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [release-83] - 2022-09-28
+
+- RMI-401: Replaced UI instaces of "Framework" with "Agreement", to web pages, or where it will be seen on the site.
+- RMI-353: Add additional year filter to the completed tasks page.
+- RMI-522: Include Glassbox into the cookie configuration and page.
+
 ## [release-82] - 2022-07-28
 
 - RMI-516: Add glassbox domains to CSP whitelist
@@ -439,6 +445,7 @@
 
 Initial release
 
+[release-83]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-82...release-83
 [release-82]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-81...release-82
 [release-81]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-80...release-81
 [release-80]: https://github.com/Crown-Commercial-Service/DataSubmissionService/compare/release-79...release-80

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -12,7 +12,7 @@
 
     %ul{ :class => 'govuk-list govuk-list--bullet' }
       %li
-        get the template for your framework(s)
+        get the template for your agreement(s)
       %li
         report your management information to CCS
       %li

--- a/app/views/no_businesses/new.html.haml
+++ b/app/views/no_businesses/new.html.haml
@@ -13,7 +13,7 @@
 
     %p
       By reporting no business you are confirming that you have no transactions
-      to report on this framework.
+      to report on this agreement.
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/submissions/completed.html.haml
+++ b/app/views/submissions/completed.html.haml
@@ -23,7 +23,7 @@
     %dl.govuk-summary-list.govuk-summary-list--no-border
       .govuk-summary-list__row
         %dt.govuk-summary-list__key
-          Framework
+          Agreement
         %dd.govuk-summary-list__value
           = @task.framework.short_name
           = @task.framework.name

--- a/app/views/support/frameworks.html.haml
+++ b/app/views/support/frameworks.html.haml
@@ -4,6 +4,6 @@
       Check which service to report to
 
     %p
-      As of March 2020, all frameworks should be reported using this service.
+      As of March 2020, all agreements should be reported using this service.
 
     = link_to('Back', '/',{ :class => 'govuk-back-link', :title => 'Link to start page'})

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -51,7 +51,7 @@
       %li
         the month and year of the task
       %li
-        the framework name and number
+        the agreement name and number
       %li
         the email address you are using to log in
       %li

--- a/app/views/tasks/_no_tasks.html.haml
+++ b/app/views/tasks/_no_tasks.html.haml
@@ -2,4 +2,4 @@
   .ccs-task__information
     .ccs-task__body
       %p All your tasks are complete.
-      %p You’re up to date on all frameworks.
+      %p You’re up to date on all agreements.

--- a/app/views/tasks/correct.html.haml
+++ b/app/views/tasks/correct.html.haml
@@ -13,7 +13,7 @@
     %dl.govuk-summary-list.govuk-summary-list--no-border
       .govuk-summary-list__row
         %dt.govuk-summary-list__key
-          Framework
+          Agreement
         %dd.govuk-summary-list__value
           = @task.framework.short_name
           = @task.framework.name

--- a/app/views/tasks/history.html.haml
+++ b/app/views/tasks/history.html.haml
@@ -22,7 +22,7 @@
             %h2.govuk-accordion__section-heading
               %span#accordion-with-summary-sections-heading-1.govuk-accordion__section-button.ccs-accordion__section-button
                 %h3.govuk-heading-s
-                  Framework
+                  Agreement
           #accordion-with-summary-sections-content-1.govuk-accordion__section-content{"aria-labelledby" => "accordion-with-summary-sections-heading-1"}
             .govuk-form-group
               %fieldset.govuk-fieldset


### PR DESCRIPTION
## Description
RMI-401

## Why was the change made?
"Framework" usage is being refined out by CCS, and so this replaces any UI viewable instances with "Agreement", as required.

## Are there any dependencies required for this change?
No, but same changes also made in the API.

## What type of change is it?

 [X] New feature 

## How was the change tested?
Non required, as there are no functional or server changes, they are only superficial changes.
