### PR TITLE
Feature/rmi 419 agreements page status filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [release-84] - 2022-10-??
 
 - RMI-33: New agreements page
-- RMI-419: Added status filter to Agreements page
+- RMI-419: Added status filter to Agreements page 
 
 ## [release-83] - 2022-09-29
 

--- a/app/views/agreements/index.html.haml
+++ b/app/views/agreements/index.html.haml
@@ -11,6 +11,9 @@
       %noscript
         %p
           Please enable javascript for sorting and filtering.
+      .ccs-filters-intro{class: 'govuk-!-padding-1'}
+        = link_to 'Clear filters', agreements_path, { class: 'ccs-clear-filters', 'aria-label' => 'Clear filters'}
+        %h2.govuk-heading-m Apply filters
       #accordion-with-summary-sections.ccs-accordion.ccs-accordion--clean{"data-module" => "govuk-accordion"}
         .govuk-accordion__section.ccs-accordion__section--clean.govuk-form-group.govuk-form-group--enclosure.ccs-form-group--enclosure--tight
           .govuk-accordion__section-header


### PR DESCRIPTION
## Description
Added status filter to agreements page (added 'Apply filters' heading and 'clear filters' link)
https://crowncommercialservice.atlassian.net/browse/RMI-419

## Why was the change made?
Improve user experience

## Are there any dependencies required for this change?
Update in API must be deployed

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually