### PR TITLE
Update active css govuk tag

### DIFF
--- a/app/views/agreements/_agreements.html.haml
+++ b/app/views/agreements/_agreements.html.haml
@@ -8,7 +8,7 @@
           = "(#{agreement.framework.short_name})"
         
         - if agreement.active
-          %strong.govuk-tag.govuk-tag__success Active
+          %strong.govuk-tag.govuk-tag__active Active
         - else
           %strong.govuk-tag.govuk-tag__notice Inactive
 


### PR DESCRIPTION
## Description
Added status filter to agreements page (used tags to show whether agreements are active or inactive), and updates the tag being used.
https://crowncommercialservice.atlassian.net/browse/RMI-419

## Why was the change made?
Improve user experience

## Are there any dependencies required for this change?
Update in API must be deployed

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually