### PR TITLE
Update active tag colour

### DIFF
--- a/app/views/agreements/_agreements.html.haml
+++ b/app/views/agreements/_agreements.html.haml
@@ -8,7 +8,7 @@
           = "(#{agreement.framework.short_name})"
         
         - if agreement.active
-          %strong.govuk-tag.govuk-tag--turquoise Active
+          %strong.govuk-tag.govuk-tag{style: "color: #10403c, background: #bfe3e0;"} Active
         - else
           %strong.govuk-tag.govuk-tag__notice Inactive
 


### PR DESCRIPTION
## Description
Updates the filter tags being used, to match the turquoise GDS spec: https://design-system.service.gov.uk/components/tag/.
https://crowncommercialservice.atlassian.net/browse/RMI-419

## Why was the change made?
Improve user experience

## Are there any dependencies required for this change?
Update in API must be deployed

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually