### PR TITLE
RMI-527

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,6 @@ class TasksController < ApplicationController
              .where(status: ['unstarted', 'in_progress', 'correcting'])
              .includes(:framework, :active_submission, :latest_submission)
              .all
-             .sort_by! { |t| Date.parse(t.due_on) }
   end
 
   def show

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -1,8 +1,8 @@
 %tr.govuk-table__row{ id: "task-#{task.id}" }
   %td.govuk-table__cell
     %h2.govuk-heading-m
-      = task.framework.short_name
       = task.framework.name
+      = "(#{task.framework.short_name})"
       for
       = task.reporting_period
 


### PR DESCRIPTION
## Description
Change the way tasks are displayed on supplier home page
https://crowncommercialservice.atlassian.net/browse/RMI-527

## Why was the change made?
In order to have consistent way in which suppliers see the agreements.

## Are there any dependencies required for this change?
Changes in API support the sorting requirements in this ticket

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually
