### PR TITLE
RMI-502

### DIFF
--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -58,4 +58,4 @@
 
     %p
       Have no business to report?
-      = link_to 'Report no business', new_task_no_business_path(task_id: @task.id), {'aria-label' => "Report no business for #{@task.supplier_name} on #{@task.framework.short_name}"}
+      = link_to 'Report no business', new_task_no_business_path(task_id: @task.id, correction: params[:correction]), {'aria-label' => "Report no business for #{@task.supplier_name} on #{@task.framework.short_name}"}


### PR DESCRIPTION
## Description
Workday transaction was not reversed when a submission was replaced.
https://crowncommercialservice.atlassian.net/browse/RMI-502

## Why was the change made?
A supplier submitted an MI return and was invoiced, and then subsequently replaced that return and was invoiced again. However, the first invoice was not credited as intended.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually