### PR TITLE
Feature/rmi 427 workday invoice no integration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,7 @@ Metrics/LineLength:
     Max: 120
     Exclude:
         - 'lib/tasks/yarn.rake'
+        - 'spec/support/api_helpers.rb'
 
 Metrics/BlockLength:
     Max: 40

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,7 +11,7 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = API::Task.includes(:framework, active_submission: :files).find(params[:id]).first
+    @task = API::Task.includes(:framework, active_submission: :invoice_details, active_submission: :files).find(params[:id]).first
     @submission = @task.active_submission
     @file = @submission.files&.first
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,7 +11,7 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = API::Task.includes(:framework, active_submission: :invoice_details, active_submission: :files).find(params[:id]).first
+    @task = API::Task.includes(:framework, active_submission: %i[invoice_details files]).find(params[:id]).first
     @submission = @task.active_submission
     @file = @submission.files&.first
   end

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -41,6 +41,27 @@
           %dd.govuk-summary-list__value
             = link_to(@file.filename, download_task_submission_path(@task, @submission))
 
+      - if @submission.invoice_details.present?
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Invoice number
+          %dd.govuk-summary-list__value
+            = @submission.invoice_details[:invoice_number]
+
+      - if @submission.invoice_details.present?
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Invoice amount
+          %dd.govuk-summary-list__value
+            = "£#{@submission.invoice_details[:invoice_amount]}"
+
+      - if @submission.invoice_details.present?
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Payment status
+          %dd.govuk-summary-list__value
+            = @submission.invoice_details[:payment_status]
+
     - if @submission.report_no_business?
       %p.ccs-return.ccs-return--no-business
         You reported no business

--- a/spec/features/user_can_cancel_correction_spec.rb
+++ b/spec/features/user_can_cancel_correction_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Cancelling a correction submission' do
       end
       mock_correcting_task_endpoint!
       mock_correction_cancellation = mock_correction_cancellation_endpoint!
-      mock_correcting_task_with_framework_and_active_submission_endpoint!
+      mock_correcting_task_with_framework_invoice_details_and_active_submission_endpoint!
       click_button 'Cancel correction'
       expect(mock_correction_cancellation).to have_been_requested
       expect(current_path).to eq(task_path('b847e0f7-027e-4b95-afa2-3490b8d05a1d'))

--- a/spec/features/user_can_correct_submission_with_mi_return_spec.rb
+++ b/spec/features/user_can_correct_submission_with_mi_return_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Correcting a submission by reporting MI return' do
       click_link 'Completed tasks'
 
       mock_completed_task_endpoint!
+      mock_completed_task_with_invoice_details_endpoint!
       within('.govuk-table__body') do
         first(:link, 'View').click
       end

--- a/spec/features/user_can_correct_submission_with_no_business_spec.rb
+++ b/spec/features/user_can_correct_submission_with_no_business_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Correcting a submission by reporting no business' do
     context 'when the latest submission is a business return' do
       before do
         mock_completed_task_endpoint!
+        mock_completed_task_with_invoice_details_endpoint!
       end
 
       scenario 'user corrects a submission, reporting "no business" when linked to one supplier' do
@@ -91,6 +92,7 @@ RSpec.feature 'Correcting a submission by reporting no business' do
     context 'when the latest submission is a no business' do
       before do
         mock_completed_task_with_no_business_endpoint!
+        mock_completed_task_with_no_business_with_invoice_details_endpoint!
       end
 
       scenario 'user cannot correct a no business with no business' do

--- a/spec/features/users_can_download_their_submissions_spec.rb
+++ b/spec/features/users_can_download_their_submissions_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'downloading a submission' do
     mock_user_endpoint!
     mock_incomplete_tasks_endpoint!
 
-    mock_completed_task_endpoint!
+    mock_completed_task_with_invoice_details_endpoint!
 
     visit '/'
     click_button 'sign-in'

--- a/spec/fixtures/mocks/completed_task.json
+++ b/spec/fixtures/mocks/completed_task.json
@@ -51,7 +51,12 @@
         "order_count": 99,
         "other_count": 0,
         "invoice_total_value": 12345.67,
-        "order_total_value": 987.65
+        "order_total_value": 987.65,
+        "invoice_details":{
+          "invoice_number":"CINV-00123456",
+          "invoice_amount":"123.45",
+          "payment_status":"Unpaid"
+       }
       },
       "relationships": {
         "files": {

--- a/spec/fixtures/mocks/completed_task_with_no_business.json
+++ b/spec/fixtures/mocks/completed_task_with_no_business.json
@@ -49,7 +49,8 @@
         "purchase_order_number": null,
         "invoice_count": 0,
         "order_count": 0,
-        "other_count": 0
+        "other_count": 0,
+        "invoice_details": null
       },
       "relationships": {
         "files": {

--- a/spec/fixtures/mocks/correcting_task_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/correcting_task_with_framework_and_active_submission.json
@@ -51,7 +51,8 @@
         "order_count": 99,
         "other_count": 0,
         "invoice_total_value": 12345.67,
-        "order_total_value": 987.65
+        "order_total_value": 987.65,
+        "invoice_details": null
       },
       "relationships": {
         "files": {

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -155,6 +155,8 @@ RSpec.describe 'the tasks list' do
       expect(response.body).to include '42'
       expect(response.body).to include '£12,345.67'
       expect(response.body).to include 'RM3786 MISO Data Template (August 2018).xls'
+      expect(response.body).to include 'CINV-00123456'
+      expect(response.body).to include 'Unpaid'
     end
   end
 

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'the tasks list' do
 
   context 'when viewing a completed task that reported business' do
     before do
-      mock_completed_task_endpoint!
+      mock_completed_task_with_invoice_details_endpoint!
       mock_user_endpoint!
       stub_signed_in_user
 
@@ -162,7 +162,7 @@ RSpec.describe 'the tasks list' do
 
   context 'when viewing a completed task that reported no business' do
     before do
-      mock_completed_task_with_no_business_endpoint!
+      mock_completed_task_with_no_business_with_invoice_details_endpoint!
       mock_user_endpoint!
       stub_signed_in_user
 

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -203,6 +203,14 @@ module ApiHelpers
       )
   end
 
+  def mock_correcting_task_with_framework_invoice_details_and_active_submission_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_correcting_task_id}?include=framework,active_submission.invoice_details,active_submission.files"))
+      .to_return(
+        headers: json_headers,
+        body: json_fixture_file('correcting_task_with_framework_and_active_submission.json')
+      )
+  end
+
   def mock_task_with_unsafe_short_name_framework_endpoint!(include_file: false)
     json = JSON.parse(File.read(json_fixture_file('task_with_framework.json')))
     json['included'][0]['attributes']['short_name'] = 'CBOARD/5'
@@ -271,6 +279,11 @@ module ApiHelpers
       .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
   end
 
+  def mock_completed_task_with_invoice_details_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,active_submission.invoice_details,active_submission.files"))
+      .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
+  end
+
   def mock_task_endpoint!
     stub_request(:get, api_url("tasks/#{mock_task_id}"))
       .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
@@ -287,6 +300,11 @@ module ApiHelpers
 
   def mock_completed_task_with_no_business_endpoint!
     stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,active_submission.files"))
+      .to_return(headers: json_headers, body: json_fixture_file('completed_task_with_no_business.json'))
+  end
+
+  def mock_completed_task_with_no_business_with_invoice_details_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,active_submission.invoice_details,active_submission.files"))
       .to_return(headers: json_headers, body: json_fixture_file('completed_task_with_no_business.json'))
   end
 


### PR DESCRIPTION
## Description
Add invoice details to completed task page where relevant using Workday API call
https://crowncommercialservice.atlassian.net/browse/RMI-427

## Why was the change made?
Improve user experience

## Are there any dependencies required for this change?
Changes in API must be deployed

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Unit and manual testing