### PR TITLE
RMI-637

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_deploy:
   - echo "install cloudfoundry cli"
   - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
   - echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+  - sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com --refresh-keys
   - sudo apt-get update -qq
   - sudo apt-get install cf7-cli
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - RMI-627: Improve loading time of URN list page
 - RMI-630: Minor content updates for URN list page
+- RMI-637: fix for GPG error in build
 
 ## [release-96] - 2023-07-06
 


### PR DESCRIPTION
## Description
GDS have upgraded buildpacks, this requires updates in the RMI apps.
https://crowncommercialservice.atlassian.net/browse/RMI-637

## Why was the change made?
To avoid deployment builds from failing.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually in development environment
