### PR TITLE
GMBP-97: Allow RMI (frontend) to build and run tests within Jenkins

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,7 +1,7 @@
 ---
 version: "3"
 services:
-  datasubmissionserviceapi:
+  test:
     image: datasubmissionserviceapi:$COMMIT_HASH
     environment:
       RAILS_ENV: "test"

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,39 @@
+---
+version: "3"
+services:
+  datasubmissionserviceapi:
+    image: datasubmissionserviceapi:$COMMIT_HASH
+    environment:
+      RAILS_ENV: "test"
+      DATABASE_URL: "postgres://postgres:password@db-test:5432/DataSubmissionService_test?template=template0&pool=5&encoding=unicode"
+      API_ROOT: "https://ccs.api/"
+    env_file:
+      - docker-compose.env
+    volumes:
+      - .:/srv/dss:cached
+      - node_modules:/srv/dss/node_modules
+    depends_on:
+      - db-test
+    command: ["bundle", "exec", "./bin/dsetup && spring server"]
+    restart: on-failure
+    networks:
+      - tests
+    container_name: data-submission-service_test
+
+  db-test:
+    image: postgres
+    volumes:
+      - pg_test_data:/var/lib/postgresql/data/:cached
+    networks:
+      - tests
+    restart: on-failure
+    container_name: data-submission-service_db-test
+    environment:
+      POSTGRES_PASSWORD: "password"
+
+networks:
+  tests:
+
+volumes:
+  pg_test_data: {}
+  node_modules:

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -3,17 +3,17 @@
 COMMIT_HASH=$(git rev-parse --short HEAD)
 export COMMIT_HASH
 
-docker build -t datasubmissionservice:$COMMIT_HASH .
+docker build -t datasubmissionservice:$COMMIT_HASH --build-arg RAILS_ENV=test .
 
-docker compose --file docker-compose.test.yml --env-file docker-compose.env build
-docker compose --file docker-compose.test.yml --env-file docker-compose.env up -d db-test
-docker compose --file docker-compose.test.yml --env-file docker-compose.env up -d test
+docker compose --file docker-compose.build.yml --env-file docker-compose.env build
+docker compose --file docker-compose.build.yml --env-file docker-compose.env up -d db-test
+docker compose --file docker-compose.build.yml --env-file docker-compose.env up -d test
 
-docker exec -it data-submission-service-api_test bundle exec rake default
+docker exec -it -e RAILS_ENV=test data-submission-service-api_test bundle exec rake default
 
 if [ $? -ne 0 ]; then
   echo "Tests failed! Exiting with status 1..."
   exit 1
 fi
 
-docker compose --file docker-compose.test.yml --env-file docker-compose.env down
+docker compose --file docker-compose.build.yml --env-file docker-compose.env down

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+COMMIT_HASH=$(git rev-parse --short HEAD)
+export COMMIT_HASH
+
+docker build -t datasubmissionservice:$COMMIT_HASH .
+
+docker compose --file docker-compose.test.yml --env-file docker-compose.env build
+docker compose --file docker-compose.test.yml --env-file docker-compose.env up -d db-test
+docker compose --file docker-compose.test.yml --env-file docker-compose.env up -d test
+
+docker exec -it data-submission-service-api_test bundle exec rake default
+
+if [ $? -ne 0 ]; then
+  echo "Tests failed! Exiting with status 1..."
+  exit 1
+fi
+
+docker compose --file docker-compose.test.yml --env-file docker-compose.env down


### PR DESCRIPTION
This allows us to build a docker image and run those tests from a single command docker-tests.sh
https://crowncommercialservice.atlassian.net/browse/GMBP-97