### PR TITLE
Feature/rmi 646 update authentication

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -16,6 +16,7 @@ applications:
       - DSSAPI
       - APP_SECRETBASE
       - GOOGLE_IDS
+      - AUTH_SECRET
     env:
       RAILS_ENV: production
       RACK_ENV: production

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'mini_racer'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.11', '>= 2.11.5'
 
+gem 'jwt', '~> 2.2'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -61,7 +63,7 @@ gem 'skylight', '~> 5.3', '>= 5.3.4'
 gem 'sprockets-rails', '~> 3.4', '>= 3.4.2'
 
 # Auth0 client for user setup scripts
-gem 'auth0', require: false
+gem 'auth0', '~> 4.17', require: false
 
 # Locking above vulnerable version https://nvd.nist.gov/vuln/detail/CVE-2019-5477
 gem 'nokogiri', '>= 1.13.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
       railties (>= 5.1)
     hashdiff (1.0.1)
     hashie (5.0.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
@@ -229,9 +229,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0808)
     mini_mime (1.1.2)
     mini_portile2 (2.8.4)
     mini_racer (0.8.0)
@@ -421,7 +421,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.7)
+    unf_ext (0.0.8.2)
     unicode-display_width (2.3.0)
     version_gem (1.1.1)
     web-console (4.2.0)
@@ -445,7 +445,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  auth0
+  auth0 (~> 4.17)
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   brakeman
@@ -461,6 +461,7 @@ DEPENDENCIES
   jquery-rails (>= 4.6.0)
   js_cookie_rails (~> 2.2, >= 2.2.0)
   jsonapi-consumer (~> 1.0, >= 1.0.1)
+  jwt (~> 2.2)
   kaminari (>= 1.2.2)
   listen (>= 3.0.5, < 3.2)
   lograge (>= 0.13.0)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,9 +2,9 @@ class SessionsController < ApplicationController
   skip_before_action :ensure_user_signed_in
 
   def create
-    session[:auth_id] = auth_hash.uid
+    session[:auth_id] = auth_id
 
-    Auditor.new.user_signed_in(user_id: auth_hash.uid)
+    Auditor.new.user_signed_in(user_id: auth_id)
 
     redirect_to '/tasks'
   end
@@ -19,6 +19,10 @@ class SessionsController < ApplicationController
   end
 
   protected
+
+  def auth_id
+    Auth.issue(auth_hash.uid)
+  end
 
   def auth_hash
     request.env['omniauth.auth']

--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -1,14 +1,15 @@
 class Auth
   ALGORITHM = 'HS256'.freeze
-  
+
   def self.issue(payload)
     JWT.encode(
-        payload,
-        auth_secret,
-        ALGORITHM)
+      payload,
+      auth_secret,
+      ALGORITHM
+    )
   end
 
   def self.auth_secret
-    ENV["AUTH_SECRET"]
+    ENV['AUTH_SECRET']
   end
 end

--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -1,0 +1,14 @@
+class Auth
+  ALGORITHM = 'HS256'.freeze
+  
+  def self.issue(payload)
+    JWT.encode(
+        payload,
+        auth_secret,
+        ALGORITHM)
+  end
+
+  def self.auth_secret
+    ENV["AUTH_SECRET"]
+  end
+end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -21,7 +21,7 @@ module ApiHelpers
   end
 
   def mock_auth_id
-    'auth0|123456'
+    'eyJhbGciOiJIUzI1NiJ9.ImF1dGgwfDEyMzQ1NiI.-MroB4ActYlc-0-XG1UrdbdDfhY0MbD86TMdLv4P5ig'
   end
 
   def mock_user_id

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -1,5 +1,5 @@
 module RequestSpecHelpers
   def stub_signed_in_user
-    allow_any_instance_of(ApplicationController).to receive(:current_user_id).and_return('auth0|123456')
+    allow_any_instance_of(ApplicationController).to receive(:current_user_id).and_return('eyJhbGciOiJIUzI1NiJ9.ImF1dGgwfDEyMzQ1NiI.-MroB4ActYlc-0-XG1UrdbdDfhY0MbD86TMdLv4P5ig')
   end
 end

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -1,5 +1,6 @@
 module RequestSpecHelpers
   def stub_signed_in_user
-    allow_any_instance_of(ApplicationController).to receive(:current_user_id).and_return('eyJhbGciOiJIUzI1NiJ9.ImF1dGgwfDEyMzQ1NiI.-MroB4ActYlc-0-XG1UrdbdDfhY0MbD86TMdLv4P5ig')
+    allow_any_instance_of(ApplicationController).to receive(:current_user_id)
+      .and_return('eyJhbGciOiJIUzI1NiJ9.ImF1dGgwfDEyMzQ1NiI.-MroB4ActYlc-0-XG1UrdbdDfhY0MbD86TMdLv4P5ig')
   end
 end


### PR DESCRIPTION
## Description
Enable encryption of traffic between front-end and API layer
https://crowncommercialservice.atlassian.net/browse/RMI-646

## Why was the change made?
To meet the requirements laid out by the TDDA papers 72 & 73

## Are there any dependencies required for this change?
Update to env vars, also API change to be deployed simultaneously

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual testing
