### PR TITLE
RMI-665

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'omniauth-rails_csrf_protection', '>= 1.0.1'
 
 # API requests
 gem 'httparty', '>= 0.21.0'
-gem 'jsonapi-consumer', '~> 1.0', '>= 1.0.1'
+gem 'jsonapi-consumer', git: 'https://github.com/jsmestad/jsonapi-consumer.git', ref: '7d9721e'
 
 # Pagination
 gem 'kaminari', '>= 1.2.2'
@@ -57,8 +57,6 @@ gem 'rollbar'
 
 # Logging
 gem 'lograge', '>= 0.13.0'
-
-# gem 'skylight', '~> 6.0', '>= 6.0.0'
 
 gem 'sprockets-rails', '~> 3.4', '>= 3.4.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/jsmestad/jsonapi-consumer.git
+  revision: 7d9721ea7feb888ea1e43edb9f1c0c38334762ed
+  ref: 7d9721e
+  specs:
+    jsonapi-consumer (2.0.0.pre)
+      activemodel (>= 3.2)
+      activesupport (>= 3.2)
+      addressable (~> 2.8.0)
+      faraday (>= 0.9)
+      faraday_middleware
+      request_store (>= 1.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -74,8 +87,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     auth0 (4.17.0)
       jwt (~> 2.2.0)
@@ -146,30 +159,10 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.10.2)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.0.0)
+    faraday (1.2.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday_middleware (1.2.0)
       faraday (~> 1.0)
     ffi (1.15.5)
     globalid (1.2.1)
@@ -207,12 +200,6 @@ GEM
     js_cookie_rails (2.2.0)
       railties (>= 3.1)
     json (2.6.3)
-    jsonapi-consumer (1.0.1)
-      activemodel (>= 3.2)
-      activesupport (>= 3.2)
-      addressable (~> 2.5.2)
-      faraday (>= 0.9)
-      faraday_middleware
     jwt (2.2.3)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -257,7 +244,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.1)
     multi_xml (0.6.0)
-    multipart-post (2.2.3)
+    multipart-post (2.3.0)
     mutex_m (0.1.2)
     net-imap (0.4.0)
       date
@@ -494,7 +481,7 @@ DEPENDENCIES
   jbuilder (~> 2.11, >= 2.11.5)
   jquery-rails (>= 4.6.0)
   js_cookie_rails (~> 2.2, >= 2.2.0)
-  jsonapi-consumer (~> 1.0, >= 1.0.1)
+  jsonapi-consumer!
   jwt (~> 2.2)
   kaminari (>= 1.2.2)
   listen (~> 3.5, >= 3.5.1)


### PR DESCRIPTION
## Description
Address vulnerability issue in jsonapi-consumer gem
https://crowncommercialservice.atlassian.net/browse/RMI-664

## Why was the change made?
Available gem version depended on a vulnerable version of addressable gem

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
N/A
