### PR TITLE
RMI-632

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -14,7 +14,7 @@ class SubmissionsController < ApplicationController
   end
 
   def show
-    @task = API::Task.includes(:framework).find(params[:task_id]).first
+    @task = API::Task.includes(:framework, :active_submission).find(params[:task_id]).first
     @submission = API::Submission.includes(:files).find(params[:id]).first
     @file = @submission.files&.first
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -36,7 +36,7 @@ class TasksController < ApplicationController
   end
 
   def cancel_correction_confirmation
-    @task = API::Task.includes(:framework).find(params[:id]).first
+    @task = API::Task.includes(:framework, :active_submission).find(params[:id]).first
 
     redirect_to root_path unless @task.correcting?
   end

--- a/app/views/submissions/ingest_failed.html.haml
+++ b/app/views/submissions/ingest_failed.html.haml
@@ -22,6 +22,10 @@
           in Excel format (.xls or .xlsx)
 
     = link_to 'Upload file', new_task_submission_path(@task.id, correction: params[:correction]), class: 'govuk-button'
+    - if @task.can_report_no_business?
+      = link_to 'Report no business', new_task_no_business_path(task_id: @task.id, correction: params[:correction]), {class: 'govuk-button', 'aria-label' => "Report no business for #{@task.supplier_name} on #{@task.framework.short_name}"}
+    - else 
+      = link_to 'Report no business', cancel_correction_confirmation_task_path(@task), {class: 'govuk-button', 'aria-label' => "Cancel correction on #{@task.framework.short_name} for #{@task.reporting_period}"}
 
     %p
       If your file is in the correct format but it is not being accepted please contact

--- a/app/views/submissions/validation_failed.html.haml
+++ b/app/views/submissions/validation_failed.html.haml
@@ -26,3 +26,7 @@
       = render('errors_table', errors: errors, sheet_name: sheet_name) if errors.any?
 
     = link_to 'Upload amended file', new_task_submission_path(@task.id, correction: params[:correction]), class: 'govuk-button'
+    - if @task.can_report_no_business?
+      = link_to 'Report no business', new_task_no_business_path(task_id: @task.id, correction: params[:correction]), {class: 'govuk-button', 'aria-label' => "Report no business for #{@task.supplier_name} on #{@task.framework.short_name}"}
+    - else 
+      = link_to 'Report no business', cancel_correction_confirmation_task_path(@task), {class: 'govuk-button', 'aria-label' => "Cancel correction on #{@task.framework.short_name} for #{@task.reporting_period}"}

--- a/app/views/tasks/cancel_correction_confirmation.html.haml
+++ b/app/views/tasks/cancel_correction_confirmation.html.haml
@@ -8,9 +8,13 @@
       Confirm correction cancellation
 
     = render 'shared/task_signpost', task: @task
-
-    %p
-      By cancelling this correction you will still be required to pay the management charge from the existing submission you made.
+      
+    - if !@task.can_report_no_business?
+      %p 
+        You have previously reported no business.
+    - else
+      %p
+        By cancelling this correction you will still be required to pay the management charge from the existing submission you made.
     %p
       Any correction files uploaded will be deleted.
 

--- a/spec/features/user_can_cancel_correction_spec.rb
+++ b/spec/features/user_can_cancel_correction_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Cancelling a correction submission' do
       mock_incomplete_tasks_endpoint!
       click_button 'sign-in'
 
-      mock_correcting_task_with_framework_endpoint!
+      mock_correcting_task_with_framework_and_active_submission_endpoint!
       within '#task-b847e0f7-027e-4b95-afa2-3490b8d05a1d' do
         click_link 'Cancel correction'
       end

--- a/spec/features/user_can_correct_submission_with_no_business_spec.rb
+++ b/spec/features/user_can_correct_submission_with_no_business_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Correcting a submission by reporting no business' do
     mock_incomplete_tasks_endpoint!
     mock_complete_tasks_endpoint!
     mock_task_with_framework_endpoint!
+    mock_task_with_framework_and_active_submission_endpoint!
     mock_no_business_correction_endpoint!
     mock_submission_completed_no_business_endpoint!
   end

--- a/spec/features/user_can_submit_feedback_spec.rb
+++ b/spec/features/user_can_submit_feedback_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Submitting customer effort score' do
     mock_sso_with(email: 'email@example.com')
     mock_incomplete_tasks_endpoint!
     mock_task_with_framework_endpoint!
+    mock_task_with_framework_and_active_submission_endpoint!
     mock_no_business_endpoint!
     mock_submission_completed_no_business_endpoint!
   end

--- a/spec/features/user_can_submit_no_business_spec.rb
+++ b/spec/features/user_can_submit_no_business_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Submitting no business' do
     mock_sso_with(email: 'email@example.com')
     mock_incomplete_tasks_endpoint!
     mock_task_with_framework_endpoint!
+    mock_task_with_framework_and_active_submission_endpoint!
     mock_no_business_endpoint!
     mock_submission_completed_no_business_endpoint!
   end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'the submission page' do
   before do
-    mock_task_with_framework_endpoint!
+    mock_task_with_framework_and_active_submission_endpoint!
     mock_user_endpoint!
   end
 

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -196,7 +196,7 @@ module ApiHelpers
   end
 
   def mock_correcting_task_with_framework_and_active_submission_endpoint!
-    stub_request(:get, api_url("tasks/#{mock_correcting_task_id}?include=framework,active_submission.files"))
+    stub_request(:get, api_url("tasks/#{mock_correcting_task_id}?include=framework,active_submission"))
       .to_return(
         headers: json_headers,
         body: json_fixture_file('correcting_task_with_framework_and_active_submission.json')


### PR DESCRIPTION
## Description
Added no business button to errored submission pages
https://crowncommercialservice.atlassian.net/browse/RMI-632

## Why was the change made?
To allow suppliers to easily report no business if they've loaded a spreadsheet in error.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual testing
