### PR TITLE
Feature/nrmi 28 change banner to details component

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -138,6 +138,27 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
       } // end of exists
 
+      const detailsElement = document.getElementById('notification');
+      if (detailsElement) {
+        const notificationId = detailsElement.getAttribute('data-notification-id');
+        const lastNotificationId = sessionStorage.getItem('last-notification-id');
 
+        if (notificationId !== lastNotificationId) {
+            sessionStorage.removeItem('details-open-${notificationId}');
+            sessionStorage.setItem('last-notification-id', notificationId);
+            detailsElement.setAttribute('open', 'true');
+        } else {
+            const savedState = sessionStorage.getItem('details-open-${notificationId}');
+            if (savedState === 'false') {
+                detailsElement.removeAttribute('open');
+            } else {
+                detailsElement.setAttribute('open', 'true');
+            }
+        }        
+
+        detailsElement.addEventListener('toggle', function () {
+            sessionStorage.setItem('details-open-${notificationId}', detailsElement.hasAttribute('open'));
+        });
+      }
 
 });

--- a/app/views/shared/_notification.html.haml
+++ b/app/views/shared/_notification.html.haml
@@ -1,8 +1,8 @@
 .grid-row
   .column-full
-    .govuk-notification-banner{"aria-labelledby" => "govuk-notification-banner-title", "data-module" => "govuk-notification-banner", role: "region"}
-      .govuk-notification-banner__header
-        %h2#govuk-notification-banner-title.govuk-notification-banner__title
-          Important
-      .govuk-notification-banner__content
+    %details#notification.govuk-details{ data: { notification_id: @notification.id }, open: true }
+      %summary.govuk-details__summary.govuk-heading-m
+        %span.govuk-details__summary-text
+          = @notification.summary.html_safe
+      .govuk-details__text
         = @notification.notification_message.html_safe

--- a/spec/features/user_can_see_published_notification_spec.rb
+++ b/spec/features/user_can_see_published_notification_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'User can see published notification' do
 
     click_on 'sign-in'
 
+    expect(page).to have_content 'Oh hello'
     expect(page).to have_content 'Testy McTestface'
   end
 end

--- a/spec/fixtures/mocks/notification.json
+++ b/spec/fixtures/mocks/notification.json
@@ -3,7 +3,8 @@
         "id": "01aea3c3-c3fa-40b5-aed4-51ba7a5c0596",
         "type": "notifications",
         "attributes": {
-            "notification_message": "<p class=\"govuk-notification-banner__heading\">Testy McTestface</p>"
+            "summary": "Oh hello",
+            "notification_message": "<p class=\"govuk-body\">Testy McTestface</p>"
         }
     },
     "jsonapi": {


### PR DESCRIPTION
## Description
Update notification banner to use detail component instead
https://crowncommercialservice.atlassian.net/browse/NRMI-28

## Why was the change made?
Reduce the annoying aspects of current functionality to encourage the use of it.

## Are there any dependencies required for this change?
Changes to API to be deployed simultaneously.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Unit, feature and manual testing
