### PR TITLE
NRMI-85: fix for session end error page

### DIFF
--- a/app/controllers/submission_completion_controller.rb
+++ b/app/controllers/submission_completion_controller.rb
@@ -1,4 +1,6 @@
 class SubmissionCompletionController < ApplicationController
+  protect_from_forgery with: :null_session
+
   def create
     submission = API::Submission.includes(:task).find(params[:submission_id]).first
     submission.complete unless submission.status == 'completed'


### PR DESCRIPTION
## Description
- [NRMI-85: Fix for error page on submit when session has ended](https://crowncommercialservice.atlassian.net/browse/NRMI-85)

## Why was the change made?
Improved user experience and reduce support queries

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
