### PR TITLE
Feature/nrmi 80 select valid outstanding tasks

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -161,4 +161,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
         });
       }
 
+      let allSelected = false;
+
+      document.getElementById('toggle_select').addEventListener('click', function(e) {
+        e.preventDefault();
+        const checkboxes = document.querySelectorAll('.govuk-checkboxes__input');
+        allSelected = !allSelected;
+
+        checkboxes.forEach(checkbox => checkbox.checked = allSelected);
+
+        this.textContent = allSelected ? 'Deselect All' : 'Select all';
+      })
+
 });

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -67,11 +67,9 @@ class TasksController < ApplicationController
     @suppliers_and_tasks = API::Task.index_by_supplier
   end
 
-  def bulk_confirm
-  end
+  def bulk_confirm; end
 
-  def bulk_create
-  end
+  def bulk_create; end
 
   private
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -63,6 +63,16 @@ class TasksController < ApplicationController
     )
   end
 
+  def bulk_new
+    @suppliers_and_tasks = API::Task.index_by_supplier
+  end
+
+  def bulk_confirm
+  end
+
+  def bulk_create
+  end
+
   private
 
   def load_frameworks

--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -6,6 +6,7 @@ module API
 
     custom_endpoint :no_business, on: :member, request_method: :post
     custom_endpoint :cancel_correction, on: :member, request_method: :patch
+    custom_endpoint :index_by_supplier, on: :collection, request_method: :get
 
     def complete?
       status == 'completed'

--- a/app/views/tasks/bulk_confirm.html.haml
+++ b/app/views/tasks/bulk_confirm.html.haml
@@ -1,0 +1,6 @@
+- page_title 'Confirm no business for 2 or more tasks'
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Coming soon to an RMI near you.

--- a/app/views/tasks/bulk_new.html.haml
+++ b/app/views/tasks/bulk_new.html.haml
@@ -1,0 +1,29 @@
+- page_title 'Report no business for 2 or more tasks'
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Report no business for 2 or more tasks
+
+    = form_tag(bulk_confirm_tasks_path, method: :post, enforce_utf8: false, remote: :true) do
+      .govuk-form-group
+        %fieldset.govuk-fieldset{"aria-describedby" => "unstarted-tasks-hint"}
+          %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
+            %h1.govuk-fieldset__heading
+              What tasks do you want to report no business for?
+          #unstarted-tasks-hint.govuk-hint
+            Select at least one option.
+          #select-deselect-link{ class: 'govuk-!-margin-bottom-4' }
+            = link_to 'Select/Deselect all tasks', '#', id: 'toggle_select'
+          .govuk-checkboxes{"data-module" => "govuk-checkboxes"}
+            - @suppliers_and_tasks.each do |supplier|
+              - if current_user.multiple_suppliers?
+                %h2.govuk-heading-m
+                  = supplier.name
+              - supplier.tasks.each do |task|
+                .govuk-checkboxes__item
+                  = check_box_tag('task_id[]', task.id, false,
+                    id: "task_id_#{task.id}",
+                    class: 'govuk-checkboxes__input')
+                  = label_tag "task_id_#{task.id}", "#{task.framework.name} (#{task.framework.short_name}) for #{task.reporting_period}", class: 'govuk-checkboxes__label'
+      = submit_tag 'Report no business', data: { 'prevent-double-click': true }, class: 'govuk-button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   resources :tasks, only: %i[index show] do
     collection do
       get :history
+      get :bulk_new
+      post :bulk_confirm
+      post :bulk_create
     end
     member do
       get :correct

--- a/spec/fixtures/mocks/tasks_index_by_supplier.json
+++ b/spec/fixtures/mocks/tasks_index_by_supplier.json
@@ -1,0 +1,177 @@
+{
+    "data": [
+        {
+            "id": "d5e739e1-596e-435b-93a0-f3c7d9d9e3aa",
+            "type": "suppliers",
+            "attributes": {
+                "name": "Bandersnatch"
+            },
+            "relationships": {
+                "tasks": {
+                    "data": [
+                        {
+                            "type": "tasks",
+                            "id": "af669abb-4674-43ba-88a6-a938c11e86a5"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "id": "a768587b-1502-4dbf-ad4a-0ee8a8f31a22",
+            "type": "suppliers",
+            "attributes": {
+                "name": "Greggs"
+            },
+            "relationships": {
+                "tasks": {
+                    "data": [
+                        {
+                            "type": "tasks",
+                            "id": "aae5bfb4-696f-4c4e-bfd9-08e18e3e65aa"
+                        },
+                        {
+                            "type": "tasks",
+                            "id": "10f33115-6d35-4de1-9bd4-82d3eb30b446"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "included": [
+        {
+            "id": "af669abb-4674-43ba-88a6-a938c11e86a5",
+            "type": "tasks",
+            "attributes": {
+                "status": "unstarted",
+                "framework_id": "5d1b9b14-fbda-4f41-a57d-ab53f1034ebd",
+                "supplier_id": "d5e739e1-596e-435b-93a0-f3c7d9d9e3aa",
+                "supplier_name": "Bandersnatch",
+                "description": null,
+                "due_on": "2024-12-06",
+                "period_year": 2024,
+                "period_month": 11,
+                "past_submissions": null,
+                "file_key": null,
+                "file_name": null
+            },
+            "relationships": {
+                "active_submission": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "latest_submission": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "submissions": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "framework": {
+                    "data": {
+                        "type": "frameworks",
+                        "id": "5d1b9b14-fbda-4f41-a57d-ab53f1034ebd"
+                    }
+                }
+            }
+        },
+        {
+            "id": "aae5bfb4-696f-4c4e-bfd9-08e18e3e65aa",
+            "type": "tasks",
+            "attributes": {
+                "status": "unstarted",
+                "framework_id": "5d1b9b14-fbda-4f41-a57d-ab53f1034ebd",
+                "supplier_id": "a768587b-1502-4dbf-ad4a-0ee8a8f31a22",
+                "supplier_name": "Greggs",
+                "description": null,
+                "due_on": "2024-11-07",
+                "period_year": 2024,
+                "period_month": 10,
+                "past_submissions": null,
+                "file_key": null,
+                "file_name": null
+            },
+            "relationships": {
+                "active_submission": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "latest_submission": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "submissions": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "framework": {
+                    "data": {
+                        "type": "frameworks",
+                        "id": "5d1b9b14-fbda-4f41-a57d-ab53f1034ebd"
+                    }
+                }
+            }
+        },
+        {
+            "id": "10f33115-6d35-4de1-9bd4-82d3eb30b446",
+            "type": "tasks",
+            "attributes": {
+                "status": "unstarted",
+                "framework_id": "5d1b9b14-fbda-4f41-a57d-ab53f1034ebd",
+                "supplier_id": "a768587b-1502-4dbf-ad4a-0ee8a8f31a22",
+                "supplier_name": "Greggs",
+                "description": null,
+                "due_on": "2024-10-07",
+                "period_year": 2024,
+                "period_month": 9,
+                "past_submissions": null,
+                "file_key": null,
+                "file_name": null
+            },
+            "relationships": {
+                "active_submission": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "latest_submission": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "submissions": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "framework": {
+                    "data": {
+                        "type": "frameworks",
+                        "id": "5d1b9b14-fbda-4f41-a57d-ab53f1034ebd"
+                    }
+                }
+            }
+        },
+        {
+            "id": "5d1b9b14-fbda-4f41-a57d-ab53f1034ebd",
+            "type": "frameworks",
+            "attributes": {
+                "short_name": "RM3781",
+                "name": "Multifunctional Devices, Managed Print and Content",
+                "file_key": "q5huwc0nssycrr01buqkx4pg6ulp",
+                "file_name": "RM3781 Multifunctional Devices, Managed Print and Content Template (3).xls"
+            }
+        }
+    ],
+    "jsonapi": {
+        "version": "1.0"
+    }
+}

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -109,6 +109,24 @@ RSpec.describe 'the tasks list' do
     end
   end
 
+  context 'when viewing select tasks for bulk no business journey' do
+    before do
+      mock_tasks_bulk_new_endpoint!
+      mock_user_with_multiple_suppliers_endpoint!
+      mock_notifications_endpoint!
+      stub_signed_in_user
+      get bulk_new_tasks_path
+    end
+
+    it 'shows supplier names' do
+      expect(response.body).to include 'Bandersnatch'
+    end
+
+    it 'shows unstarted tasks with framework name and due period' do
+      expect(response.body).to include 'Multifunctional Devices, Managed Print and Content (RM3781) for November 2024'
+    end
+  end
+
   context 'when viewing task history' do
     before do
       mock_complete_tasks_endpoint!

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -423,6 +423,14 @@ module ApiHelpers
       )
   end
 
+  def mock_tasks_bulk_new_endpoint!
+    stub_request(:get, api_url('tasks/index_by_supplier'))
+      .to_return(
+        headers: json_headers,
+        body: json_fixture_file('tasks_index_by_supplier.json')
+      )
+  end
+
   private
 
   def json_headers


### PR DESCRIPTION
## Description
- [NRMI-80: Select tasks page for bulk no business journey](https://crowncommercialservice.atlassian.net/browse/NRMI-80)

## Why was the change made?
Minimise input/effort/repetition/time when completing nil returns

## Are there any dependencies required for this change?
API changes must be deployed first

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Unit and manual testing
