### PR TITLE
feature/nrmi-86: add back button to all task submission output pages

### DIFF
--- a/app/views/submissions/ingest_failed.html.haml
+++ b/app/views/submissions/ingest_failed.html.haml
@@ -1,5 +1,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
+    = link_to 'Back', tasks_path, { class: 'govuk-back-link', title: 'Back to your tasks' }
+    
     %h1.govuk-heading-xl
       We were unable to process your file
 

--- a/app/views/submissions/validation_failed.html.haml
+++ b/app/views/submissions/validation_failed.html.haml
@@ -2,6 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
+    = link_to 'Back', tasks_path, { class: 'govuk-back-link', title: 'Back to your tasks' }
 
 .govuk-grid-row
   .govuk-grid-column-full


### PR DESCRIPTION
## Description
- [NRMI-86: Add back link to post submission validation pages](https://crowncommercialservice.atlassian.net/browse/NRMI-86)

## Why was the change made?
Consistency with all journeys from tasks page, improved user experience.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually
