### PR TITLE
NRMI-114: update wording on tasks complete page

### DIFF
--- a/app/views/submissions/completed.html.haml
+++ b/app/views/submissions/completed.html.haml
@@ -72,19 +72,22 @@
       What happens next
     %p
       We will contact you if we need more information about what you have told us.
+
     - if @completed_tasks
       %p
-        If you’ve made a mistake or need to amend the management information 
-        you’ve supplied, email 
-        = mail_to(support_email_address)
-        for help.
+        If you’ve made a mistake or need to amend the management information you’ve supplied
+        = link_to 'view your completed tasks.', history_tasks_path
     - else
       %p
         If you’ve made a mistake or need to amend the management information 
         you’ve supplied, #{link_to 'correct this return', correct_task_path(@task)}.
+
     - if @tasks.any?
       %p
         = link_to 'Complete another task', tasks_path,  {class: 'govuk-button'}
+    - elsif @completed_tasks
+      %p 
+        = link_to 'Sign out', sign_out_path, {class: 'govuk-button'}
     - else
       %p 
         = link_to 'View your completed tasks', history_tasks_path, {class: 'govuk-!-margin-right-3'}

--- a/spec/features/user_can_bulk_report_no_business_spec.rb
+++ b/spec/features/user_can_bulk_report_no_business_spec.rb
@@ -36,6 +36,7 @@ RSpec.feature 'Bulk reporting no business' do
     click_on 'Confirm no business'
 
     expect(page).to have_content 'Tasks complete'
-    expect(page).to have_content 'email report-mi@crowncommercial.gov.uk for help'
+    expect(page).to have_content 'to amend the management information you’ve supplied view your completed tasks'
+    expect(page).to have_content 'Complete another task'
   end
 end


### PR DESCRIPTION
## Description
- [NRMI-114: update 'what happens next' wording](https://crowncommercialservice.atlassian.net/browse/NRMI-114)

## Why was the change made?
Reduced support query / improved self serve mindset for supplier users.

## Are there any dependencies required for this change?
No
## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual test
