### PR TITLE
NRMI-106

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,10 +23,6 @@ module ApplicationHelper
     ENV['CORRECTION_RETURNS_ENABLED'].present?
   end
 
-  def survey_url
-    'https://crowncommercial.qualtrics.com/jfe/form/SV_7a44L3eBrOGDCVU'
-  end
-
   def about_cookies_url
     'http://www.aboutcookies.org/'
   end

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -6,8 +6,6 @@
           Support links
         %ul.govuk-footer__inline-list
           %li.govuk-footer__inline-list-item
-            %a.govuk-link{:href => survey_url, :class => "govuk-footer__link"} Feedback
-          %li.govuk-footer__inline-list-item
             = link_to "Accessibility statement", accessibility_path, class: "govuk-footer__link"
           %li.govuk-footer__inline-list-item
             = link_to "Cookie settings", cookie_settings_path, class: "govuk-footer__link"


### PR DESCRIPTION
## Description
- [NRMI-106: Remove the dead 'Feedback' link from the footer.](https://crowncommercialservice.atlassian.net/browse/NRMI-106)

## Why was the change made?
Clean up dead link

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
