### PR TITLE
NRMI-128

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,8 +6,11 @@ class ErrorsController < ApplicationController
   end
 
   def internal_server_error
+    flash[:alert] = params[:error_description] if params[:error_description].present?
     render status: :internal_server_error
   end
 
-  def auth_failure; end
+  def auth_failure
+    flash[:alert] = params[:error_description] if params[:error_description].present?
+  end
 end

--- a/app/views/errors/auth_failure.html.haml
+++ b/app/views/errors/auth_failure.html.haml
@@ -6,7 +6,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %p
-      We were unable to sign you in with the provided credentials. Please try again.
+      We were unable to sign you in with the provided credentials.
 
     %p{class: 'govuk-!-margin-top-9'}
       = button_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"


### PR DESCRIPTION
## Description
- [NRMI-128: Improved error messaging for account lockout policy
](https://crowncommercialservice.atlassian.net/browse/NRMI-128)

## Why was the change made?
To avoid user confusion

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
